### PR TITLE
Switch to device IP to differentiate architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Python packages.
 
    * Determines the compute capability available on the system.
    * Resolves with compute capability compatibility in mind.
-   * Returns feature list in the form of `xpu::device_type::<arch>`
+   * Returns feature list in the form of `xpu::device_ip::<ip>`
+   * Each value (`<ip>`) in the list represents human readable form of
+     Intel hardware device IP (GMDID) quariable via Level Zero [ZE_extension_device_ip_version]
 
 ## Configuring Your Project
 
@@ -25,3 +27,50 @@ requires = ["provider_variant_xpu"]
 enable-if = "platform_system == 'Linux'"
 plugin-api = "provider_variant_xpu.plugin:XpuVariantPlugin"
 ```
+
+## Understanding Intel Device IP Values
+
+Device IP is an identifier (GMDID) assigned to differentiate architectures of
+compute platforms of Intel GPU devices. Few different Intel GPU devices (with
+the different device IDs) might be built on the same compute platform.
+
+Programmatically device IP can be queried for each Intel GPU device using
+Level Zero [ZE_extension_device_ip_version] API. Returned value format is
+Intel specific and requires conversion to human readable form.
+
+Intel offline compiler (`ocloc`) generates code for one or few target compute
+platforms passed in `-device <device_type>` argument. Each `<device type> in
+the list can be set as Device IP or via acronym name internally mapped to the
+respective Device IP. To query Device IP(s) for the specific acronym
+`ocloc ids` command can be used. For example:
+
+```
+$ ocloc ids bmg
+Matched ids:
+20.1.0
+
+$ ocloc ids xe3
+Matched ids:
+30.0.0
+30.0.4
+30.1.0
+30.1.1
+```
+
+For Python package to target specific Intel architectures using XPU variant
+provider plugin, it's required to build package variants for these
+architectures and set `xpu::device_ip::<ip>` properties accordingly. For the
+above example of `bmg` and `xe3` that would be:
+
+```
+# for bmg variant:
+xpu::device_ip::20.1.0
+
+# for xe3 variant:
+xpudevice_ip::30.0.0
+xpudevice_ip::30.0.4
+xpudevice_ip::30.1.0
+xpudevice_ip::30.1.1
+```
+
+[ZE_extension_device_ip_version]: https://oneapi-src.github.io/level-zero-spec/level-zero/latest/core/EXT_DeviceIpVersion.html#ze-extension-device-ip-version

--- a/provider_variant_xpu/devices.py
+++ b/provider_variant_xpu/devices.py
@@ -1,32 +1,122 @@
 # Copyright (c) 2025 Intel Corporation
 
-# Dictionary to match device ids of Intel GPUs with respective device type
-# names as known to ocloc (see `-device` option description in `ocloc compile --help`)
+import ctypes
+
+# Dictionary describing Intel device IPs (platforms).
 #
-# Support notes:
-# * Device types MUST use [a-z0-9_.] character set
-# * Add newer hardware on top
-# * Add device types with better performance first
-# * Refer hardware tabel in https://dgpu-docs.intel.com/devices/hardware-table.html
-devices = {
-    0x0bd5: [ "pvc" ],
-    0x0bda: [ "pvc" ],
-    0xe20b: [ "bmg" ],
-    0xe20c: [ "bmg" ],
-    0x64a0: [ "lnl" ],
-    0x6420: [ "lnl" ],
-    0x64b0: [ "lnl" ],
-    0x7d51: [ "arl_h" ],
-    0x7d67: [ "arl_s" ],
-    0x7d41: [ "arl_u" ],
-    0x7dd5: [ "mtl" ],
-    0x7d45: [ "mtl" ],
-    0x7d40: [ "mtl" ],
-    0x7d55: [ "mtl" ],
-    0x56a0: [ "dg2" ],
-    0x56a1: [ "dg2" ],
-    0x56a2: [ "dg2" ],
-    0x56a5: [ "dg2" ],
-    0x56a6: [ "dg2" ],
-    0x46a6: [ "adl_p" ],
+# Dictionary keys are represented by device IP versions which can be queried
+# with Level Zero "ZE_extension_device_ip_version" API. Version value format
+# is driver specific and requires decoding to the human readable format we
+# use in the table below. For Intel devices values encode GMDID identifiers.
+#
+# Dictionary values provide the following information for each device IP:
+# * `devices` - list of strings each representing device name built with this
+#   device IP. These names are synonims which can be used in `ocloc` compiler
+#   to build code for this device IP.
+# * `compat` - device IP of the base platform. Code for the base platform can
+#   be executed on all the platforms with the same compatible name.
+# * `compat_name` - name assigned to device IP of the base platform. This name
+#   is used in `ocloc` compiler to build code for the base platform.
+_intel_devips = {
+    "20.4.4": {
+        "devices": ["lnl-m"],
+        "compat": "20.1.0",
+    },
+    "20.2.0": {
+        "devices": ["bmg-g31"],
+        "compat": "20.1.0"
+    },
+    "20.1.0": {
+        "devices": ["bmg-g21"],
+        "compat_name": "bmg",
+    },
+    "12.74.4": {
+        "devices": ["arl-h"]
+    },
+    "12.71.4": {
+        "devices": ["mtl-h"],
+        "compat": "12.70.4",
+    },
+    "12.70.4": {
+        "devices": ["mtl-u", "arl-u", "arl-s"],
+        "compat_name": "mtl",
+    },
+    "12.60.7": {
+        "devices": ["pvc"],
+    },
+    "12.57.0": {
+        "devices": ["acm-g12", "dg2-g12"],
+        "compat": "12.55.8",
+    },
+    "12.56.5": {
+        "devices": ["acm-g11", "dg2-g11", "ats-m75"],
+        "compat": "12.55.8",
+    },
+    "12.55.8": {
+        "devices": ["acm-g10", "dg2-g10", "ats-m150"],
+        "compat_name": "dg2",
+    },
+    "12.10.0": {
+        "devices": ["dg1"],
+    },
+    "12.4.0": {
+        "devices": ["adl-n"],
+    },
+    "12.3.0": {
+        "devices": ["adl-p", "rpl-p"],
+    },
+    "12.2.0": {
+        "devices": ["adl-s", "rpl-s"],
+    },
+    "12.1.0": {
+        "devices": ["rkl"],
+    },
+    "12.0.0": {
+        "devices": ["tgllp", "tgl"],
+    },
 }
+
+def get_all_ips():
+    return list(_intel_devips.keys())
+
+# See: https://github.com/intel/compute-runtime/blob/25.27.34303.6/shared/source/helpers/hw_ip_version.h
+class c_intelIPVersion_t(ctypes.Union):
+    _fields_ = [
+        ("revision", ctypes.c_uint32, 6),
+        ("reserved", ctypes.c_uint32, 8),
+        ("release", ctypes.c_uint32, 8),
+        ("architecture", ctypes.c_uint32, 10),
+        ("value", ctypes.c_uint32)
+    ]
+
+# NOTE: The better way would be to inherit from ctypes.Union and use bit fields.
+# NOTE: Unfortunately python ctypes seems to have bug handling bit fields...
+class IntelDeviceIp:
+    # See: https://github.com/intel/compute-runtime/blob/25.27.34303.6/shared/source/helpers/hw_ip_version.h
+    ip_version = 0
+    revision = 0
+    release = 0
+    architecture = 0
+
+    def __init__(self, devip: ctypes.c_uint32):
+        self.ip_version = devip
+        self.revision = devip & 0x3F  # 6 bits value
+        self.release = (devip >> 14) & 0xFF
+        self.architecture = devip >> 22
+
+    def __str__(self):
+        return f"{self.architecture}.{self.release}.{self.revision}"
+
+    def get_compat(self):
+        ip = str(self)
+        if ip in _intel_devips:
+            if "compat" in _intel_devips[ip]:
+                return _intel_devips[ip]["compat"]
+        return ""
+
+    def get_all_compat_ips(self):
+        ips = [ str(self) ]
+        compat = self.get_compat()
+        if compat:
+            ips += [compat]
+        return ips

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,12 @@ authors = [
 dynamic = ["version", "description"]
 dependencies = []
 
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-mock",
+]
+
 [project.urls]
 Home = "https://github.com/wheelnext/provider-variant-xpu/"
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2025 Intel Corporation
+
+import pytest
+import re
+
+from provider_variant_xpu.devices import *
+from provider_variant_xpu.devices import _intel_devips
+
+pattern = re.compile("^[a-z0-9_.]+$")
+
+def test_pattern():
+    """Sanity test for the pattern"""
+    assert pattern.fullmatch("abc")
+    assert pattern.fullmatch("abc_1")
+    assert pattern.fullmatch("abc.1")
+    assert not pattern.fullmatch("abc-1")
+    assert not pattern.fullmatch("ABC")
+
+def to_uint32_devip(ip: str):
+    devip = [int(x) for x in ip.split('.')]
+    assert len(devip) == 3
+    (arch, release, revision) = devip
+    assert (revision & ~0x3F) == 0
+    assert (release & ~0xFF) == 0
+    assert (arch & ~0xFF) == 0
+    return (revision & 0x3F) | (release << 14) | (arch << 22)
+
+def test_to_uint32_devip():
+    assert to_uint32_devip("12.60.7") == 0x030f0007
+    assert to_uint32_devip("12.55.8") == 0x030dc008
+    bad_revision = 0x4F
+    with pytest.raises(AssertionError):
+        to_uint32_devip(f"0.0.{bad_revision}")
+    with pytest.raises(AssertionError):
+        to_uint32_devip(f"0.256.0")
+    with pytest.raises(AssertionError):
+        to_uint32_devip(f"256.0.0")
+    with pytest.raises(AssertionError):
+        to_uint32_devip(f"1.2.3.4")
+
+def test_intel_devips():
+    """Test internal device IP table"""
+    for key, value in _intel_devips.items():
+        assert pattern.fullmatch(key)
+        ignore_result = to_uint32_devip(key)
+        assert value
+        assert "devices" in value
+        for d in value["devices"]:
+            assert isinstance(d, str)
+            assert d != ""
+        if "compat" in value:
+            assert isinstance(value["compat"], str)
+            compat = value["compat"]
+            assert compat in _intel_devips
+            assert "compat_name" not in value
+        elif "compat_name" in value:
+            assert isinstance(value["compat_name"], str)
+            assert value["compat_name"] != ""
+            assert pattern.fullmatch(value["compat_name"])
+
+def test_IntelDeviceIp_not_in_table():
+    """Test device IP handling of the IP not in the internal table"""
+    ip = IntelDeviceIp(0x12341234)
+    str_ip = str(ip)
+    # sanity check that we did not hit table entry
+    assert str_ip not in _intel_devips
+    # any IP should match the pattern
+    assert pattern.fullmatch(str_ip)
+    assert str_ip == "72.208.52"
+    # should not have compat as it's not in table
+    assert not ip.get_compat()
+    # all compat should just have single entry of IP itself
+    all_ips = ip.get_all_compat_ips()
+    assert len(all_ips) == 1
+    assert all_ips[0] == str_ip
+
+def test_IntelDeviceIp_in_table():
+    for key, value in _intel_devips.items():
+        ip = IntelDeviceIp(to_uint32_devip(key))
+        str_ip = str(ip)
+        compat_ip = ip.get_compat()
+        all_ips = ip.get_all_compat_ips()
+        assert str_ip == key
+        if "compat" in value:
+            assert len(all_ips) == 2
+            assert all_ips[0] == str_ip
+            assert all_ips[1] == value["compat"]
+            assert compat_ip == value["compat"]
+        else:
+            assert len(all_ips) == 1
+            assert all_ips[0] == str_ip
+            assert compat_ip == ""

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2025 Intel Corporation
+
+import pytest
+
+from variantlib.models.provider import VariantFeatureConfig
+from variantlib.models.variant import VariantProperty
+
+# Importing the whole module to be able to access modifications
+# to internal module variables (such as _g_zelib).
+import provider_variant_xpu.ze as ze
+
+from provider_variant_xpu.devices import _intel_devips
+from provider_variant_xpu.plugin import XpuVariantPlugin
+from provider_variant_xpu.ze import *
+
+@pytest.fixture
+def plugin() -> XpuVariantPlugin:
+    return XpuVariantPlugin()
+
+def test_validate_property(plugin):
+    for key in _intel_devips.keys():
+        prop = f"xpu :: device_ip :: {key}"
+        assert plugin.validate_property(VariantProperty.from_str(prop))
+
+def test_validate_property_assert(plugin):
+    with pytest.raises(AssertionError):
+        plugin.validate_property(VariantProperty.from_str(
+            "notxpu :: device_ip :: 12.55.8"))
+
+def test_validate_property_fail_warn(plugin):
+    with pytest.warns(UserWarning):
+        assert not plugin.validate_property(VariantProperty.from_str(
+            "xpu :: nosuchprop :: 12.55.8"))
+
+def test_validate_property_fail(plugin):
+    assert not plugin.validate_property(VariantProperty.from_str(
+        "xpu :: device_ip :: 0.0.0"))
+
+
+class TestGetSupportedConfigs:
+    zelib_orig = None
+    zelib_cache_orig = ( dict() )
+    cdll_name = "provider_variant_xpu.ze.CDLL"
+
+    def setup_method(self, method):
+        self.zelib_orig = ze.g_zelib
+        self.zelib_cache_orig = ze.g_zelib_cache
+        ze.g_zelib = None
+        ze.g_zelib_cache = ( dict() )
+
+    def teardown_method(self, method):
+        ze.g_zelib = self.zelib_orig
+        ze.g_zelib_cache = self.zelib_cache_orig
+
+    def test_no_L0_library(self, plugin, mocker):
+        mocker.patch(self.cdll_name, side_effect=OSError("No such file"))
+        with pytest.warns(UserWarning):
+            assert not plugin.get_supported_configs(None)


### PR DESCRIPTION
Device IP versions identify Intel compute platforms and allows to avoid device id mappings because they are programmatically quarriable.

The change switches to use `xpu::device_ip::<ip>`. Device IP values are quariable via L0 API and via `ocloc ids` command line.

The downside using device IP is lesser familiarity of community with device IP. Device IP numeric values (like `12.60.7` representing `pvc`) are less known than string values and are not self-speaking because of that. Advantage of device IP is that it's quarriable programmatically and causes less efforts to support the variant plugin. Note that compatibility story still needs to be hardcoded as compat device IP can't be currently queried programmatically.